### PR TITLE
Replace static with public

### DIFF
--- a/index.js
+++ b/index.js
@@ -114,7 +114,7 @@ export default class extends Component {
       }),
       fs.mkdir('lib'),
       fs.mkdir('components'),
-      fs.mkdir('static'),
+      fs.mkdir('public'),
       fs.writeFile('README.md', `
 # ${name}
 


### PR DESCRIPTION
The static directory has been deprecated in favour of the public directory: https://github.com/zeit/next.js/blob/master/errors/static-dir-deprecated.md